### PR TITLE
ppg_server config

### DIFF
--- a/conf/ppg_server
+++ b/conf/ppg_server
@@ -1,0 +1,30 @@
+process {
+  // These are default values used for anything not specified with a label.
+  cpus = 1
+  memory = 1.GB
+
+  withLabel: download {
+    errorStrategy = "retry"
+    maxRetries = 5
+  }
+
+  withLabel: small_task {
+    cpus = 1
+    memory = 2.GB
+  }
+
+  withLabel: medium_task {
+    cpus = 4
+    memory = 6.GB
+  }
+
+  withLabel: biggish_task {
+    cpus = 8
+    memory = 14.GB
+  }
+
+  withLabel: big_task {
+    cpus = 12
+    memory = 30.GB
+  }
+}


### PR DESCRIPTION
To take advantage of the resources on the server. Nimbus config crashes due to amount of CPUs and the next 'smaller' config doesn't take full advantage of what the server can handle.